### PR TITLE
UserRoles endpoint will return an empty list instead of unauthorized

### DIFF
--- a/app/policies/user_role_policy.rb
+++ b/app/policies/user_role_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class UserRolePolicy < ApplicationPolicy
   def index?
-    @user.role?('admin') || @user.role?('manager') || @user.role?('contributor')
+    true
   end
 
   def show?

--- a/spec/controllers/user_roles_controller_spec.rb
+++ b/spec/controllers/user_roles_controller_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe UserRolesController, type: :controller do
     subject { get :index, format: :json }
 
     context 'when not signed in' do
-      it { expect(subject).to be_forbidden }
+      it 'shows an empty list' do
+        json = JSON.parse(subject.body)
+        expect(json['data'].length).to eq(0)
+      end
     end
 
     context 'when signed in' do
@@ -23,7 +26,8 @@ RSpec.describe UserRolesController, type: :controller do
 
       it 'does not show anything to guest user' do
         sign_in guest
-        expect(subject).to be_forbidden
+        json = JSON.parse(subject.body)
+        expect(json['data'].length).to eq(0)
       end
 
       it 'shows only themselves for contributors' do


### PR DESCRIPTION
issue#164

UserRoles endpoint will return an empty list instead of Unauthorized