### PR TITLE
Reject updates where updated_at is older than the the server issue#155

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,4 +55,5 @@ group :test do
   gem 'poltergeist'
   gem 'pry-rails'
   gem 'shoulda-matchers'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,7 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timecop (0.8.1)
     tins (1.13.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -364,6 +365,7 @@ DEPENDENCIES
   simplecov
   spring
   thin
+  timecop
   unicorn
   unicorn-worker-killer
   web-console (~> 2.0)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -29,6 +29,9 @@ class CategoriesController < ApplicationController
 
   # PATCH/PUT /categories/1
   def update
+    if params[:category][:updated_at] && DateTime.parse(params[:category][:updated_at]).to_i != @category.updated_at.to_i
+      return render json: 'record outdated', status: :unprocessable_entity
+    end
     render json: @category if @category.update_attributes!(permitted_attributes(@category))
   end
 

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -29,6 +29,9 @@ class IndicatorsController < ApplicationController
 
   # PATCH/PUT /indicators/1
   def update
+    if params[:indicator][:updated_at] && DateTime.parse(params[:indicator][:updated_at]).to_i != @indicator.updated_at.to_i
+      return render json: 'record outdated', status: :unprocessable_entity
+    end
     render json: @indicator if @indicator.update_attributes!(permitted_attributes(@indicator))
   end
 

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -30,6 +30,9 @@ class MeasuresController < ApplicationController
 
   # PATCH/PUT /measures/1
   def update
+    if params[:measure][:updated_at] && DateTime.parse(params[:measure][:updated_at]).to_i != @measure.updated_at.to_i
+      return render json: 'record outdated', status: :unprocessable_entity
+    end
     render json: @measure if @measure.update_attributes!(permitted_attributes(@measure))
   end
 

--- a/app/controllers/progress_reports_controller.rb
+++ b/app/controllers/progress_reports_controller.rb
@@ -30,6 +30,9 @@ class ProgressReportsController < ApplicationController
 
   # PATCH/PUT /progress_reports/1
   def update
+    if params[:progress_report][:updated_at] && DateTime.parse(params[:progress_report][:updated_at]).to_i != @progress_report.updated_at.to_i
+      return render json: 'record outdated', status: :unprocessable_entity
+    end
     render json: @progress_report if @progress_report.update_attributes!(permitted_attributes(@progress_report))
   end
 

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -30,6 +30,9 @@ class RecommendationsController < ApplicationController
 
   # PATCH/PUT /recommendations/1
   def update
+    if params[:recommendation][:updated_at] && DateTime.parse(params[:recommendation][:updated_at]).to_i != @recommendation.updated_at.to_i
+      return render json: 'record outdated', status: :unprocessable_entity
+    end
     render json: @recommendation if @recommendation.update_attributes!(permitted_attributes(@recommendation))
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,10 +2,6 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  attr_accessor :last_updated_at_store
-
-  validate :not_updated_since_load, on: :update
-
   def last_modified_user_id
     return nil unless respond_to? :versions
     return nil unless versions.last
@@ -15,23 +11,5 @@ class ApplicationRecord < ActiveRecord::Base
   def last_modified_user
     return nil unless last_modified_user_id
     User.find last_modified_user_id
-  end
-
-  def last_updated_at
-    last_updated_at_store || updated_at
-  end
-
-  def last_updated_at=(value)
-    return unless value.is_a?(String)
-    return self.last_updated_at_store = DateTime.new if value.empty?
-    self.last_updated_at_store = DateTime.parse(value)
-  end
-
-  private
-
-  def not_updated_since_load
-    unless last_updated_at.to_i == updated_at.to_datetime.to_i
-      errors.add(:last_updated_at, "another update was performed on the server, please refresh")
-    end
   end
 end

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class CategoryPolicy < ApplicationPolicy
   def permitted_attributes
-    [:title, :short_title, :description, :url, :draft, :taxonomy_id, :manager_id, :last_updated_at]
+    [:title, :short_title, :description, :url, :draft, :taxonomy_id, :manager_id]
   end
 
   class Scope < Scope

--- a/app/policies/indicator_policy.rb
+++ b/app/policies/indicator_policy.rb
@@ -5,7 +5,6 @@ class IndicatorPolicy < ApplicationPolicy
      :description,
      :draft,
      :manager_id,
-     :last_updated_at,
      measure_indicators_attributes: [:measure_id,
                                      measure_attributes: [:id, :title, :description, :target_date, :draft]]]
   end

--- a/app/policies/measure_policy.rb
+++ b/app/policies/measure_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class MeasurePolicy < ApplicationPolicy
   def permitted_attributes
-    [:title, :description, :target_date, :draft, :last_updated_at,
+    [:title, :description, :target_date, :draft,
      recommendation_measures_attributes: [:recommendation_id,
                                           recommendation_attributes: [:id, :title, :number, :draft]],
      measure_categories_attributes: [:category_id,

--- a/app/policies/recommendation_policy.rb
+++ b/app/policies/recommendation_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class RecommendationPolicy < ApplicationPolicy
   def permitted_attributes
-    [:title, :number, :draft, :last_updated_at, recommendation_categories_attributes: [:category_id]]
+    [:title, :number, :draft, recommendation_categories_attributes: [:category_id]]
   end
 
   class Scope < Scope

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -21,7 +21,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:email, :password, :password_confirmation, :name, :last_updated_at]
+    [:email, :password, :password_confirmation, :name]
   end
 
   class Scope < Scope

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,13 +1,13 @@
 class ApplicationSerializer < ActiveModel::Serializer
-  attributes :id, :created_at, :last_updated_at
+  attributes :id, :created_at, :updated_at
   attribute :last_modified_user_id, if: :current_user_has_permission?
 
   def created_at
     object.created_at.in_time_zone.iso8601 if object.created_at
   end
 
-  def last_updated_at
-    object.last_updated_at.in_time_zone.iso8601 if object.last_updated_at
+  def updated_at
+    object.updated_at.in_time_zone.iso8601 if object.created_at
   end
 
   def current_user_has_permission?

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -146,18 +146,22 @@ RSpec.describe CategoriesController, type: :controller do
         sign_in user
         category_get = get :show, params: { id: category }, format: :json
         json = JSON.parse(category_get.body)
-        current_update_at = json['data']['attributes']['last_updated_at']
+        current_update_at = json['data']['attributes']['updated_at']
 
-        subject = put :update,
-                      format: :json,
-                      params: { id: category,
-                                category: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: current_update_at } }
-        expect(subject).to be_ok
-        subject = put :update,
-                      format: :json,
-                      params: { id: category,
-                                category: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: (Time.now + 5.minutes).in_time_zone.iso8601 } }
-        expect(subject).to_not be_ok
+        Timecop.travel(Time.new + 15.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: category,
+                                  category: { title: 'test update', description: 'test updateeee', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to be_ok
+        end
+        Timecop.travel(Time.new + 5.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: category,
+                                  category: { title: 'test update', description: 'test updatebbbb', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to_not be_ok
+        end
       end
 
       it 'will record what manager updated the category', versioning: true do

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -169,18 +169,22 @@ RSpec.describe IndicatorsController, type: :controller do
         sign_in user
         indicator_get = get :show, params: { id: indicator }, format: :json
         json = JSON.parse(indicator_get.body)
-        current_update_at = json['data']['attributes']['last_updated_at']
+        current_update_at = json['data']['attributes']['updated_at']
 
-        subject = put :update,
-                      format: :json,
-                      params: { id: indicator,
-                                indicator: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: current_update_at } }
-        expect(subject).to be_ok
-        subject = put :update,
-                      format: :json,
-                      params: { id: indicator,
-                                indicator: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: (Time.now + 5.minutes).in_time_zone.iso8601 } }
-        expect(subject).to_not be_ok
+        Timecop.travel(Time.new + 15.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: indicator,
+                                  indicator: { title: 'test update', description: 'test updateeee', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to be_ok
+        end
+        Timecop.travel(Time.new + 5.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: indicator,
+                                  indicator: { title: 'test update', description: 'test updatebbbb', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to_not be_ok
+        end
       end
 
       it 'will record what manager updated the indicator', versioning: true do

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -202,18 +202,22 @@ RSpec.describe MeasuresController, type: :controller do
         sign_in user
         measure_get = get :show, params: { id: measure }, format: :json
         json = JSON.parse(measure_get.body)
-        current_update_at = json['data']['attributes']['last_updated_at']
+        current_update_at = json['data']['attributes']['updated_at']
 
-        subject = put :update,
-                      format: :json,
-                      params: { id: measure,
-                                measure: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: current_update_at } }
-        expect(subject).to be_ok
-        subject = put :update,
-                      format: :json,
-                      params: { id: measure,
-                                measure: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: (Time.now + 5.minutes).in_time_zone.iso8601 } }
-        expect(subject).to_not be_ok
+        Timecop.travel(Time.new + 15.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: measure,
+                                  measure: { title: 'test update', description: 'test updateeee', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to be_ok
+        end
+        Timecop.travel(Time.new + 5.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: measure,
+                                  measure: { title: 'test update', description: 'test updatebbbb', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to_not be_ok
+        end
       end
 
       it 'will record what manager updated the measure', versioning: true do

--- a/spec/controllers/recommendations_controller_spec.rb
+++ b/spec/controllers/recommendations_controller_spec.rb
@@ -174,22 +174,26 @@ RSpec.describe RecommendationsController, type: :controller do
         expect(subject).to be_ok
       end
 
-      it 'will reject and update where the last_updated_at is older than updated_at in the database' do
+      it 'will reject an update where the last_updated_at is older than updated_at in the database' do
         sign_in user
         recommendation_get = get :show, params: { id: recommendation }, format: :json
         json = JSON.parse(recommendation_get.body)
-        current_update_at = json['data']['attributes']['last_updated_at']
+        current_update_at = json['data']['attributes']['updated_at']
 
-        subject = put :update,
-                      format: :json,
-                      params: { id: recommendation,
-                                recommendation: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: current_update_at } }
-        expect(subject).to be_ok
-        subject = put :update,
-                      format: :json,
-                      params: { id: recommendation,
-                                recommendation: { title: 'test update', description: 'test update', target_date: 'today update', last_updated_at: (Time.now + 5.minutes).in_time_zone.iso8601 } }
-        expect(subject).to_not be_ok
+        Timecop.travel(Time.new + 15.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: recommendation,
+                                  recommendation: { title: 'test update', description: 'test updateeee', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to be_ok
+        end
+        Timecop.travel(Time.new + 5.days) do
+          subject = put :update,
+                        format: :json,
+                        params: { id: recommendation,
+                                  recommendation: { title: 'test update', description: 'test updatebbbb', target_date: 'today update', updated_at: current_update_at } }
+          expect(subject).to_not be_ok
+        end
       end
 
       it 'will record what manager updated the recommendation', versioning: true do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe UsersController, type: :controller do
     subject do
       put :update,
           format: :json,
-          params: { id: contributor, user: { email: 'test@co.nz', password: 'testtest', name: 'Sam' } }
+          params: { id: contributor.id, user: { email: 'test@co.nz', password: 'testtest', name: 'Sam' } }
     end
 
     context 'when not signed in' do
@@ -138,24 +138,6 @@ RSpec.describe UsersController, type: :controller do
         expect(json['data']['id'].to_i).to eq(contributor.id)
         expect(json['data']['attributes']['email']).to eq 'test@co.nz'
         expect(json['data']['attributes']['name']).to eq 'Sam'
-      end
-
-      it 'will reject and update where the last_updated_at is older than updated_at in the database' do
-        sign_in contributor
-        contributor_get = get :show, params: { id: contributor }, format: :json
-        json = JSON.parse(contributor_get.body)
-        current_update_at = json['data']['attributes']['last_updated_at']
-
-        subject = put :update,
-                      format: :json,
-                      params: { id: contributor,
-                                user: { email: 'test@co.nz', password: 'testtest', name: 'Sam', last_updated_at: current_update_at } }
-        expect(subject).to be_ok
-        subject = put :update,
-                      format: :json,
-                      params: { id: contributor,
-                                user: { email: 'test@co.nz', password: 'testtest', name: 'Sam', last_updated_at: (Time.now + 5.minutes).in_time_zone.iso8601 } }
-        expect(subject).to_not be_ok
       end
     end
   end


### PR DESCRIPTION
Issue #155 

- Reverted attempt to build as ActiveRecord module
- Implemented rejection in controllers
- Reject updates where updated_at field sent is older than the field on the server