### PR TITLE
Added in support for updated_at check for Users.  issue#155

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,6 +31,9 @@ class UsersController < ApplicationController
 
   # PATCH/PUT /users/1
   def update
+    if params[:user][:updated_at] && DateTime.parse(params[:user][:updated_at]).to_i != @user.updated_at.to_i
+      return render json: 'record outdated', status: :unprocessable_entity
+    end
     render json: @user if @user.update_attributes!(permitted_attributes(@user))
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :user_roles
+  has_many :user_roles, dependent: :destroy
   has_many :roles, through: :user_roles
   has_many :managed_categories, foreign_key: :manager_id, class_name: Category
   has_many :managed_indicators, foreign_key: :manager_id, class_name: Indicator


### PR DESCRIPTION
Issue #155 

- Added in support for updated_at check for Users
- When a user is deleted, so are it's user_roles